### PR TITLE
Prevent LCA allocator from crashing when errors occur

### DIFF
--- a/allocator/allocator.go
+++ b/allocator/allocator.go
@@ -18,7 +18,7 @@ import (
 func main () {
     // Start Prometheus endpoint for stats collection
     http.Handle("/metrics", promhttp.Handler())
-    go http.ListenAndServe(":9100", nil)
+    go http.ListenAndServe(":9101", nil)
 
     ctx := context.Background()
 

--- a/lca/lca-defaults.go
+++ b/lca/lca-defaults.go
@@ -1,6 +1,8 @@
 package lca
 
 import (
+    "log"
+
     "github.com/libp2p/go-libp2p-core/protocol"
 
     "github.com/multiformats/go-multiaddr"
@@ -32,5 +34,8 @@ func init() {
 
     LCAAllocatorProtocolID = protocol.ID("/LCAAllocator/1.0")
     LCAAllocatorRendezvous = "QmQJRHSU69L6W2SwNiKekpUHbxHPXi57tWGRWJaD5NsRxS"
+
+    // Set up logging defaults
+    log.SetFlags(log.Ldate | log.Lmicroseconds | log.Lshortfile)
 }
 


### PR DESCRIPTION
Rather than panic'ing, just log the errors and return from `LCAAllocatorHandler()` gracefully.

Should resolve #18 