### PR TITLE
Support constant peer IDs upon restarting proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Multi-Tier-Cloud/service-manager
 go 1.13
 
 require (
-	github.com/Multi-Tier-Cloud/common v0.4.0
+	github.com/Multi-Tier-Cloud/common v0.4.1
 	github.com/Multi-Tier-Cloud/docker-driver v0.0.0-20200504140614-1940e41e8d5a
 	github.com/Multi-Tier-Cloud/hash-lookup v0.1.0
 	github.com/libp2p/go-libp2p v0.9.2

--- a/lca/lca-manager.go
+++ b/lca/lca-manager.go
@@ -9,6 +9,7 @@ import (
     "strings"
     "log"
 
+    "github.com/libp2p/go-libp2p-core/crypto"
     "github.com/libp2p/go-libp2p-core/network"
     "github.com/libp2p/go-libp2p-core/peer"
     "github.com/libp2p/go-libp2p-core/protocol"
@@ -242,12 +243,15 @@ func NewLCAManagerHandler(address string) func(network.Stream) {
 
 // Constructor for LCA Manager instance
 // If serviceName is empty string start instance in "anonymous mode"
-func NewLCAManager(ctx context.Context, serviceName string, serviceAddress string, bootstraps []string) (LCAManager, error) {
+func NewLCAManager(ctx context.Context, serviceName string,
+                    serviceAddress string, bootstraps []string,
+                    privKey crypto.PrivKey) (LCAManager, error) {
     var err error
 
     var node LCAManager
 
     config := p2pnode.NewConfig()
+    config.PrivKey = privKey
     if len(bootstraps) != 0 {
         config.BootstrapPeers = bootstraps
     }


### PR DESCRIPTION
  - The key flags are backwards-compatible with the pre-existing
    positional arguments, but they *must* be specified before them.
  - This feature is desirable in cases where a proxy, even if its in a
    container, restarts (e.g. the host the container runs on reboots).
    In such a case, the proxy should ideally retain the same ID. This
    prevents monitoring systems from thinking service churn has
    occurred, and more accurate represents the flaky nature of the host.
  - Resolves #21 for the proxy service