### PR TITLE
Enables passing bootstraps via either CLI or EnvVar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Multi-Tier-Cloud/service-manager
 go 1.13
 
 require (
-	github.com/Multi-Tier-Cloud/common v0.5.0
+	github.com/Multi-Tier-Cloud/common v0.8.0-rc1
 	github.com/Multi-Tier-Cloud/docker-driver v0.0.0-20200504140614-1940e41e8d5a
 	github.com/Multi-Tier-Cloud/hash-lookup v0.1.0
 	github.com/libp2p/go-libp2p v0.9.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Multi-Tier-Cloud/service-manager
 go 1.13
 
 require (
-	github.com/Multi-Tier-Cloud/common v0.4.1
+	github.com/Multi-Tier-Cloud/common v0.5.0
 	github.com/Multi-Tier-Cloud/docker-driver v0.0.0-20200504140614-1940e41e8d5a
 	github.com/Multi-Tier-Cloud/hash-lookup v0.1.0
 	github.com/libp2p/go-libp2p v0.9.2

--- a/lca/lca-allocator.go
+++ b/lca/lca-allocator.go
@@ -13,6 +13,8 @@ import (
     "github.com/libp2p/go-libp2p-core/protocol"
     "github.com/libp2p/go-libp2p-core/crypto"
 
+    "github.com/multiformats/go-multiaddr"
+
     "github.com/Multi-Tier-Cloud/common/p2pnode"
     "github.com/Multi-Tier-Cloud/common/util"
     "github.com/Multi-Tier-Cloud/docker-driver/docker_driver"
@@ -124,7 +126,7 @@ func LCAAllocatorHandler(stream network.Stream) {
 }
 
 // Constructor for LCA Allocator
-func NewLCAAllocator(ctx context.Context, bootstraps []string,
+func NewLCAAllocator(ctx context.Context, bootstraps []multiaddr.Multiaddr,
                         privKey crypto.PrivKey) (LCAAllocator, error) {
     var err error
     var node LCAAllocator

--- a/lca/lca-defaults.go
+++ b/lca/lca-defaults.go
@@ -7,7 +7,7 @@ import (
 
     "github.com/multiformats/go-multiaddr"
 
-    "github.com/Multi-Tier-Cloud/common/p2pnode"
+    "github.com/Multi-Tier-Cloud/common/util"
 )
 
 
@@ -23,7 +23,7 @@ var LCAAllocatorRendezvous string
 // Initialize defaults
 func init() {
     var err error
-    DefaultListenAddrs, err = p2pnode.StringsToMultiaddrs([]string{
+    DefaultListenAddrs, err = util.StringsToMultiaddrs([]string{
         "/ip4/0.0.0.0/tcp/4001",
     })
     if err != nil {

--- a/lca/lca-manager.go
+++ b/lca/lca-manager.go
@@ -14,6 +14,8 @@ import (
     "github.com/libp2p/go-libp2p-core/peer"
     "github.com/libp2p/go-libp2p-core/protocol"
 
+    "github.com/multiformats/go-multiaddr"
+
     "github.com/Multi-Tier-Cloud/common/p2pnode"
     "github.com/Multi-Tier-Cloud/common/p2putil"
     "github.com/Multi-Tier-Cloud/hash-lookup/hashlookup"
@@ -244,7 +246,7 @@ func NewLCAManagerHandler(address string) func(network.Stream) {
 // Constructor for LCA Manager instance
 // If serviceName is empty string start instance in "anonymous mode"
 func NewLCAManager(ctx context.Context, serviceName string,
-                    serviceAddress string, bootstraps []string,
+                    serviceAddress string, bootstraps []multiaddr.Multiaddr,
                     privKey crypto.PrivKey) (LCAManager, error) {
     var err error
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -16,7 +16,6 @@ import (
 
     "github.com/multiformats/go-multiaddr"
 
-    "github.com/Multi-Tier-Cloud/common/p2pnode"
     "github.com/Multi-Tier-Cloud/common/p2putil"
     "github.com/Multi-Tier-Cloud/common/util"
 
@@ -242,13 +241,23 @@ func main() {
 
     if len(*bootstraps) == 0 {
         if len(config.Bootstraps) == 0 {
-            log.Fatalln("ERROR: Must specify at least one bootstrap node" +
-                "through a command line flag or the configuration file")
-        }
+            envBootstraps, err := util.GetEnvBootstraps()
+            if err != nil {
+                log.Fatalln(err)
+            }
 
-        *bootstraps, err = p2pnode.StringsToMultiaddrs(config.Bootstraps)
-        if err != nil {
-            log.Fatalln(err)
+            if len(envBootstraps) == 0 {
+                log.Fatalf("ERROR: Must specify at least one bootstrap node " +
+                    "through a command line flag, the configuration file, or " +
+                    "setting the %s environment variable.", util.ENV_KEY_BOOTSTRAPS)
+            }
+
+            *bootstraps = envBootstraps
+        } else {
+            *bootstraps, err = util.StringsToMultiaddrs(config.Bootstraps)
+            if err != nil {
+                log.Fatalln(err)
+            }
         }
     }
 


### PR DESCRIPTION
This completely removes the dependance on hard-coded bootstraps in `common/p2pnode`. With this change, we now support 3 ways of taking bootstrap flags.

The order of precedance for specifying bootstraps are:
1. CLI flags
2. Configuration file
3. Environment variable

If multiple methods are used, we take **only take the bootstraps from the highest ranked method** (i.e. we do not take a union of the bootstraps).