### PR TITLE
Enable service chaining w/ either TCP or UDP

### DIFF
--- a/l4-proxy/chain-setup.go
+++ b/l4-proxy/chain-setup.go
@@ -1,0 +1,208 @@
+/* Functions related to setting up a service chain. These can be invoked
+ * either by the original client proxy's HTTP control handler, or by
+ * a custom P2P protocol handler.
+ */
+
+package main
+
+import (
+    "bytes"
+    "encoding/gob"
+    "fmt"
+    "log"
+
+    "github.com/libp2p/go-msgio"
+    "github.com/libp2p/go-libp2p-core/network"
+    "github.com/libp2p/go-libp2p-core/protocol"
+
+)
+
+var chainSetupProtoID = protocol.ID("/ChainSetup/1.0")
+
+// Service chain messaging protocol objects
+// Enumerate chain message types
+type ChainMsgType int
+const (
+    Error ChainMsgType = iota
+    SetupRequest
+    SetupACK
+    Data
+)
+
+func (cmType ChainMsgType) String() string {
+    switch cmType {
+    case Error:
+        return "Error"
+    case SetupRequest:
+        return "SetupRequest"
+    case SetupACK:
+        return "SetupACK"
+    case Data:
+        return "Data"
+    default:
+        return fmt.Sprintf("%d", cmType)
+    }
+}
+
+type ChainMsg struct {
+    Type    ChainMsgType
+
+    // Arbitrary data that will need further decoding, depending on Type
+    Data    []byte
+}
+
+func NewChainSetupRequest(chainSpec []string) *ChainMsg {
+    msg := &ChainMsg{Type: SetupRequest}
+    if err := EncodeChainData(msg, chainSpec); err != nil {
+        log.Printf("ERROR: Unable to encode chain spec into SetupRequest message\n%v", err)
+        return nil
+    }
+
+    return msg
+}
+
+// ACK message doesn't need a payload, but an optional string can be used for debugging
+// If not used, simply provide an empty string (i.e. "")
+func NewChainSetupACK(debug string) *ChainMsg {
+    msg := &ChainMsg{Type: SetupACK}
+    if len(debug) > 0 {
+        if err := EncodeChainData(msg, debug); err != nil {
+            // ACK message without debug msg is still valid, so just warn
+            log.Printf("WARNING: Unable to encode debug string into SetupACK message\n")
+        }
+    }
+
+    return msg
+}
+
+// Used for setting the Data field of ChainMsg
+func EncodeChainData(msg *ChainMsg, obj interface{}) error {
+    switch msg.Type {
+    case Error:
+        // Expect obj to be type: error
+        if errObj, ok := obj.(error); ok {
+            msg.Data = []byte(errObj.Error())
+        } else if str, ok := obj.(string); ok {
+            msg.Data = []byte(str)
+        } else {
+            return fmt.Errorf("ChainMsg type %s can only encode data of type 'error' or 'string'")
+        }
+    case SetupRequest:
+        chainSpec, ok := obj.([]string)
+        if !ok {
+            return fmt.Errorf("ChainMsg type %s can only encode data of type '[]string'")
+        }
+        var buf bytes.Buffer
+        enc := gob.NewEncoder(&buf)
+        enc.Encode(chainSpec)
+        msg.Data = buf.Bytes()
+    case SetupACK:
+        // Expect obj to be type: string
+        debugStr, ok := obj.(string);
+        if !ok {
+            return fmt.Errorf("ChainMsg type %s can only encode data of type 'string'")
+        }
+        msg.Data = []byte(debugStr)
+    case Data:
+        // TODO
+        fmt.Printf("TO DO\n")
+    default:
+        return fmt.Errorf("Unknown chain message type: %s\n")
+    }
+
+    return nil
+}
+
+func DecodeChainData(msg *ChainMsg) (interface{}, error) {
+    if msg == nil {
+        return nil, fmt.Errorf("ERROR: msg == nil\n")
+    }
+
+    buf := bytes.NewBuffer(msg.Data)
+    dec := gob.NewDecoder(buf)
+
+    switch msg.Type {
+    case Error:
+        errStr := string(msg.Data)
+        return fmt.Errorf(errStr), nil
+    case SetupRequest:
+        var chainSpec []string
+        dec.Decode(&chainSpec)
+        return chainSpec, nil
+    case SetupACK:
+        debug := string(msg.Data)
+        return debug, nil
+    case Data:
+        // TODO
+        return nil, nil
+    default:
+        return nil, fmt.Errorf("ERROR: Unknown chain message type: %d\n")
+    }
+
+    return nil, fmt.Errorf("ERROR: Should not reach this point... " +
+        "unless some message types are unimplemented\n")
+}
+
+func expectTypePrintErr(cm *ChainMsg, ct ChainMsgType) bool {
+    if cm.Type != ct {
+        if cm.Type == Error {
+            // Print the error message
+            actualErr, err := DecodeChainData(cm)
+            if err != nil {
+                log.Printf("ERROR: Unable to decode chain message: %v\n", err)
+            } else {
+                log.Printf("%v", actualErr)
+            }
+        } else {
+            log.Printf("ERROR: Expected a chain type %s, but got %s instead\n", ct, cm.Type)
+        }
+        return false
+    }
+
+    return true
+}
+
+// Wrappers for sending/receiving objects through the p2p stream
+// msgio is used for framing, while gob is used for encoding/decoding objects
+type chainMsgCommunicator struct {
+    stream  network.Stream
+    msgRWC  msgio.ReadWriteCloser
+    enc     *gob.Encoder
+    dec     *gob.Decoder
+}
+
+func NewChainMsgCommunicator (stream network.Stream) *chainMsgCommunicator {
+    if stream == nil {
+        return nil
+    }
+
+    cmComm := chainMsgCommunicator{stream: stream,}
+
+    // Use msgio for proper framing
+    // Keep separate handles for each so we can close independently
+    cmComm.msgRWC = msgio.Combine(msgio.NewVarintWriter(stream),
+                                    msgio.NewVarintReader(stream))
+
+    // Use gob for encoding/decoding
+    cmComm.dec = gob.NewDecoder(cmComm.msgRWC)
+    cmComm.enc = gob.NewEncoder(cmComm.msgRWC)
+
+    return &cmComm
+}
+
+func (cmsr *chainMsgCommunicator) Recv() (*ChainMsg, error) {
+    cm := &ChainMsg{}
+    if err := cmsr.dec.Decode(cm); err != nil {
+        return nil, err
+    }
+    return cm, nil
+}
+
+func (cmsr *chainMsgCommunicator) Send(obj *ChainMsg) error {
+    return cmsr.enc.Encode(obj)
+}
+
+func (cmsr *chainMsgCommunicator) GetStream() network.Stream {
+    return cmsr.stream
+}
+

--- a/l4-proxy/l4-proxy.go
+++ b/l4-proxy/l4-proxy.go
@@ -219,7 +219,7 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
     }
 
     // Check if this is a service chain, and set it up
-    err := setupChain(chainSpec)
+    _, err := setupChain(chainSpec)
     if err != nil {
         http.Error(w, "Bad Request", http.StatusBadRequest)
         log.Printf("ERROR: Chain setup failed\n%v\n", err)

--- a/l4-proxy/l4-proxy.go
+++ b/l4-proxy/l4-proxy.go
@@ -62,11 +62,11 @@ var cache pcache.PeerCache
 type Forwarder struct {
     // Use TCPAddr instead for endpoint addresses?
     ListenAddr  string
-    tcpWorker   func(net.Listener, peer.ID)
+    tcpWorker   func(net.Listener, []string)
     udpWorker   func(*net.UDPConn, []string)
 }
 
-// Maps a remote addr to existing ServiceProxy for that addr
+// Maps a remote addr to existing Forwarder for that addr
 var serv2Fwd = make(map[string]Forwarder)
 
 func findOrAllocate(serviceHash, dockerHash string) (peer.ID, error) {
@@ -234,10 +234,7 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
     // Start separate goroutine for handling connections and proxying to service
     var listenAddr string
     if tpProto == "tcp" {
-        //listenAddr, err = openTCPProxy(peerProxyID)
-        http.Error(w, "TCP chaining currently disabled", http.StatusMethodNotAllowed)
-        log.Printf("ERROR: TCP chaining currently disabled\n")
-        return
+        listenAddr, err = openTCPProxy(chainSpec)
     } else if tpProto == "udp" {
         listenAddr, err = openUDPProxy(chainSpec)
     } else {

--- a/l4-proxy/l4-proxy.go
+++ b/l4-proxy/l4-proxy.go
@@ -176,7 +176,7 @@ func createStream(targetPeer peer.ID, proto protocol.ID) (network.Stream, error)
 // if necessary.
 func resolveService(servName string) (peer.ID, error) {
     log.Println("Looking for service with name", servName, "in hash-lookup")
-    servHash, dockerHash, err := hashlookup.GetHashWithHostRouting(
+    info, err := registry.GetServiceWithHostRouting(
         manager.Host.Ctx, manager.Host.Host,
         manager.Host.RoutingDiscovery, servName)
 
@@ -186,11 +186,11 @@ func resolveService(servName string) (peer.ID, error) {
                                 servName, err)
     }
 
-    peerProxyID, err := findOrAllocate(servHash, dockerHash)
+    peerProxyID, err := findOrAllocate(info.ContentHash, info.DockerHash)
     if err != nil {
         //log.Printf("ERROR: Unable to find or allocate service %s (%s)\n%v\n", servName, servHash, err)
         return "", fmt.Errorf("ERROR: Unable to find or allocate service %s (%s)\n%v\n",
-                                servName, servHash, err)
+                                servName, info.ContentHash, err)
     }
 
     return peerProxyID, nil

--- a/l4-proxy/tcp-proxy.go
+++ b/l4-proxy/tcp-proxy.go
@@ -1,42 +1,63 @@
 package main
 
 import (
+    "errors"
     "fmt"
+    "io"
     "log"
     "net"
+    "strings"
     "syscall"
 
     "github.com/libp2p/go-libp2p-core/network"
-    "github.com/libp2p/go-libp2p-core/peer"
     "github.com/libp2p/go-libp2p-core/protocol"
-
-    "github.com/t-lin/go-libp2p-gostream"
 )
 
 var tcpTunnelProtoID = protocol.ID("/LCATunnelTCP/1.0")
 
-// TCP data forwarder
-// Simplified version of pipe() from https://github.com/jpillora/go-tcp-proxy/blob/master/proxy.go
-func tcpFwdData(src, dst net.Conn) {
+const MAX_TCP_TUNNEL_PAYLOAD = 0xffff - 20 - 20 // Max uint16 - Min TCP header size - IP header size
+
+// TODO: Only difference between this and udpFwdStream2Conn is
+//       the dstAddr param and WriteTo() in the body... can they
+//       be somehow merged?
+func tcpFwdStream2Conn(src network.Stream, dst net.Conn) {
+    // Not shared amongst multiple clients, safe to close upstream connection
+    defer func() {
+        log.Printf("Closing connection %s <=> %s\n", dst.LocalAddr(), dst.RemoteAddr())
+        src.Reset()
+        dst.Close()
+    }()
+
     var err error
     var nBytes, nBytesW, n int
-    buf := make([]byte, 0xffff) // 64k buffer
-    for {
-        nBytesW = 0
+    var data []byte
 
-        // NOTE: Using io.Copy or io.CopyBuffer slows down *a lot* after 2-3 runs.
-        //       Not clear why right now. Thus, do the copy manually.
-        nBytes, err = src.Read(buf)
-        if err != nil {
-            log.Printf("Connection %s <=> %s closed", src.LocalAddr(), src.RemoteAddr())
+    srcComm := NewChainMsgCommunicator(src)
+
+    for {
+        if data, err = receiveData(srcComm); err != nil {
+            log.Printf("ERROR: %v\n", err)
+            if errors.Is(err, syscall.EINVAL) || errors.Is(err, io.EOF) {
+                log.Printf("Connection %s <=> %s closed by remote",
+                    src.Conn().LocalPeer(), src.Conn().RemotePeer())
+            } else {
+                log.Printf("Unable to read from connection %s <=> %s\n%v\n",
+                    src.Conn().LocalPeer(), src.Conn().RemotePeer(), err)
+            }
             return
         }
-        data := buf[:nBytes]
 
+        nBytes = len(data)
+        nBytesW = 0
         for nBytesW < nBytes {
             n, err = dst.Write(data)
             if err != nil {
-                log.Printf("Connection %s <=> %s closed", dst.LocalAddr(), dst.RemoteAddr())
+                if err == syscall.EINVAL {
+                    log.Printf("Connection %s <=> %s closed", dst.LocalAddr(), dst.RemoteAddr())
+                } else {
+                    log.Printf("ERROR: Unable to write to TCP connection %s <=> %s\n%v\n",
+                        dst.LocalAddr(), dst.RemoteAddr(), err)
+                }
                 return
             }
 
@@ -45,27 +66,76 @@ func tcpFwdData(src, dst net.Conn) {
     }
 }
 
-// Connection forwarder
-func tcpFwdConnToServ(lConn net.Conn, targetPeer peer.ID) {
-    defer lConn.Close()
-    log.Printf("Accepted TCP conn: %s <=> %s\n", lConn.LocalAddr(), lConn.RemoteAddr())
+// TODO: This now seems identical to udpFwdConn2Stream... except payload size. Merge the two?
+func tcpFwdConn2Stream(src net.Conn, dst network.Stream) {
+    defer func() {
+        log.Printf("Closing connection %s <=> %s\n",
+            dst.Conn().LocalPeer(), dst.Conn().RemotePeer())
+        dst.Reset()
+        src.Close()
+    }()
 
-    p2pNode := manager.Host
-    rConn, err := gostream.Dial(p2pNode.Ctx, p2pNode.Host, targetPeer, tcpTunnelProtoID)
-    if err != nil {
-        log.Printf("ERROR: Unable to dial target peer %s\n%v\n", targetPeer, err)
-        return
+    var err error
+    var nBytes int
+    buf := make([]byte, MAX_TCP_TUNNEL_PAYLOAD)
+
+    dstComm := NewChainMsgCommunicator(dst)
+
+    for {
+        // NOTE: Using io.Copy or io.CopyBuffer slows down *a lot* after 2-3 runs.
+        //       Not clear why right now. Thus, do the copy manually.
+        nBytes, err = src.Read(buf)
+        if err != nil {
+            if errors.Is(err, syscall.EINVAL) || errors.Is(err, io.EOF) {
+                log.Printf("Connection %s <=> %s closed by remote", src.LocalAddr(), src.RemoteAddr())
+            } else {
+                log.Printf("Unable to read from TCP connection %s <=> %s\n%v\n",
+                    src.LocalAddr(), src.RemoteAddr(), err)
+            }
+            return
+        }
+        data := buf[:nBytes]
+
+        if err = sendData(dstComm, data); err != nil {
+            if errors.Is(err, syscall.EINVAL) {
+                log.Printf("Connection %s <=> %s closed",
+                    dst.Conn().LocalPeer(), dst.Conn().RemotePeer())
+            } else {
+                log.Printf("ERROR: Unable to write to connection %s <=> %s\n%v\n",
+                    dst.Conn().LocalPeer(), dst.Conn().RemotePeer(), err)
+            }
+            return
+        }
     }
-    defer rConn.Close()
-
-    // Forward data in each direction
-    go tcpFwdData(lConn, rConn)
-    tcpFwdData(rConn, lConn)
 }
 
-// Implementation of ServiceProxy
-func tcpServiceProxy(listen net.Listener, targetPeer peer.ID) {
-    defer listen.Close()
+// Connection forwarder
+// This function is separate from tcpServiceProxy() so as to avoid HOL
+// blocking in the event the chain setup takes too long and another
+// client wants to connect.
+func tcpFwdConnToServ(lConn net.Conn, chainSpec []string) {
+    log.Printf("Accepted TCP conn: %s <=> %s\n", lConn.LocalAddr(), lConn.RemoteAddr())
+
+    rConn, err := setupChain(chainSpec)
+    if err != nil {
+        log.Printf("ERROR: Unable to set up chain %s\n%v\n", chainSpec, err)
+        return
+    }
+
+    // Forward data in each direction
+    // Closing will be done within the tcpFwd* functions
+    go tcpFwdConn2Stream(lConn, rConn)
+    go tcpFwdStream2Conn(rConn, lConn)
+}
+
+// Implementation of TCP service proxy. Invoked by the source proxy in the
+// chain. Responsible for setting up the chain and passing the ingress stream
+// to the appropriate data forwarders.
+func tcpServiceProxy(listen net.Listener, chainSpec []string) {
+    defer func() {
+        log.Printf("Shutting down proxy for chain %s\n", chainSpec)
+        listen.Close()
+    }()
 
     for {
         conn, err := listen.Accept()
@@ -79,7 +149,7 @@ func tcpServiceProxy(listen net.Listener, targetPeer peer.ID) {
         }
 
         // Forward connection
-        go tcpFwdConnToServ(conn, targetPeer)
+        go tcpFwdConnToServ(conn, chainSpec)
     }
 }
 
@@ -90,9 +160,9 @@ func tcpServiceProxy(listen net.Listener, targetPeer peer.ID) {
 // TODO: In the future, perhaps the connection type info (TCP/UDP) can be stored in hash-lookup?
 //
 // Returns a string of the new TCP listening endpoint address
-func openTCPProxy(servicePeer peer.ID) (string, error) {
+func openTCPProxy(chainSpec []string) (string, error) {
     var listenAddr string
-    serviceKey := "tcp://" + string(servicePeer)
+    serviceKey := strings.Join(chainSpec, "/")
     if _, exists := serv2Fwd[serviceKey]; !exists {
         listen, err := net.Listen("tcp", ctrlHost + ":") // automatically choose port
         if err != nil {
@@ -104,7 +174,7 @@ func openTCPProxy(servicePeer peer.ID) (string, error) {
             ListenAddr: listenAddr,
             tcpWorker: tcpServiceProxy,
         }
-        go serv2Fwd[serviceKey].tcpWorker(listen, servicePeer)
+        go serv2Fwd[serviceKey].tcpWorker(listen, chainSpec)
     } else {
         listenAddr = serv2Fwd[serviceKey].ListenAddr
     }
@@ -114,10 +184,7 @@ func openTCPProxy(servicePeer peer.ID) (string, error) {
 
 // Handler for tcpTunnelProtoID (i.e. invoked at destination proxy)
 // Make a connection to the local service and forward data to/from it
-func tcpTunnelHandler(stream network.Stream) {
-    lConn := gostream.NewConn(stream)
-    defer lConn.Close()
-
+func tcpEndChainHandler(stream network.Stream) {
     // Resolve and open connection to destination service
     rAddr, err := net.ResolveTCPAddr("tcp", servEndpoint)
     if err != nil {
@@ -130,9 +197,29 @@ func tcpTunnelHandler(stream network.Stream) {
         log.Printf("ERROR: Unable to dial target address %s\n%v\n", servEndpoint, err)
         return
     }
-    defer rConn.Close()
 
     // Forward data in each direction
-    go tcpFwdData(lConn, rConn)
-    tcpFwdData(rConn, lConn)
+    go tcpFwdStream2Conn(stream, rConn)
+    go tcpFwdConn2Stream(rConn, stream)
 }
+
+func tcpMidChainHandler(inStream, outStream network.Stream) {
+    // Resolve and open connection to destination service
+    rAddr, err := net.ResolveTCPAddr("tcp", servEndpoint)
+    if err != nil {
+        log.Printf("ERROR: Unable to resolve target address %s\n%v\n", servEndpoint, err)
+        return
+    }
+
+    rConn, err := net.DialTCP("tcp", nil, rAddr)
+    if err != nil {
+        log.Printf("ERROR: Unable to dial target address %s\n%v\n", servEndpoint, err)
+        return
+    }
+
+    // Forward data in each direction
+    go tcpFwdStream2Conn(inStream, rConn)
+    go tcpFwdConn2Stream(rConn, outStream)
+    go fwdStream2Stream(outStream, inStream)
+}
+

--- a/l4-proxy/tcp-proxy.go
+++ b/l4-proxy/tcp-proxy.go
@@ -84,12 +84,10 @@ func tcpServiceProxy(listen net.Listener, targetPeer peer.ID) {
 }
 
 // Open TCP tunnel to service and open local TCP listening port
+// Start separate goroutine for handling connections and proxying to service
 // NOTE: Currently doesn't support SSL/TLS
 //
 // TODO: In the future, perhaps the connection type info (TCP/UDP) can be stored in hash-lookup?
-// TODO: In the future, move towards proxy-to-proxy implementation
-//       This may be useful? https://github.com/libp2p/go-libp2p-gostream
-// Start separate goroutine for handling connections and proxying to service
 //
 // Returns a string of the new TCP listening endpoint address
 func openTCPProxy(servicePeer peer.ID) (string, error) {

--- a/l4-proxy/udp-proxy.go
+++ b/l4-proxy/udp-proxy.go
@@ -125,16 +125,6 @@ func udpFwdConn2Stream(src net.Conn, dst network.Stream) {
     }
 }
 
-func createStream(targetPeer peer.ID) (network.Stream, error) {
-    p2pNode := manager.Host
-    stream, err := p2pNode.Host.NewStream(p2pNode.Ctx, targetPeer, udpTunnelProtoID)
-    if err != nil {
-        return nil, err
-    }
-
-    return stream, nil
-}
-
 // Demultiplex incoming packets and forward them to destination
 func udpServiceProxy(p2pNet network.Network, lConn *net.UDPConn, targetPeer peer.ID) {
     defer func() {
@@ -201,7 +191,7 @@ func udpServiceProxy(p2pNet network.Network, lConn *net.UDPConn, targetPeer peer
         if rConn, exists = client2Stream[from.String()]; !exists {
             log.Printf("New UDP conn: %s <=> %s\n", lConn.LocalAddr(), from)
 
-            if rConn, err = createStream(targetPeer); err != nil {
+            if rConn, err = createStream(targetPeer, udpTunnelProtoID); err != nil {
                 log.Printf("ERROR: Unable to dial target peer %s\n%v\n", targetPeer, err)
                 return
             }
@@ -240,7 +230,7 @@ func udpServiceProxy(p2pNet network.Network, lConn *net.UDPConn, targetPeer peer
                 //  2) Peer may have been restarted (or a momentary network disconnection)
                 // Attempt Write() again with newly created stream
                 mapMtx.Lock()
-                if rConn, err = createStream(targetPeer); err != nil {
+                if rConn, err = createStream(targetPeer, udpTunnelProtoID); err != nil {
                     log.Printf("ERROR: Unable to dial target peer %s\n%v\n", targetPeer, err)
                     return
                 }


### PR DESCRIPTION
These commits implement a working PoC of service chaining, using the API spec proposed in #50 for L4 proxying.

Tested with simple 2-VNF (i.e. 3 proxies in path, if including the source/client proxy) scenarios, using `nc` as the client and server (or `telnet` as the client in the TCP case), and using self-made UDP and TCP middleboxes that changes the payload.