### PR TITLE
Support per-service requirements in pcache and proxies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # ignore binaries
 allocator/allocator
 proxy/proxy
+l4-proxy/l4-proxy
 
 # ignore vim swapfiles
 **/*.swp

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.4.14 // indirect
-	github.com/Multi-Tier-Cloud/common v0.9.0
+	github.com/Multi-Tier-Cloud/common v0.9.1-0.20200802182723-020620a0455b
 	github.com/Multi-Tier-Cloud/docker-driver v0.2.3
 	github.com/Multi-Tier-Cloud/service-registry v0.5.0
 	github.com/gorilla/mux v1.7.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/Multi-Tier-Cloud/common v0.0.0-20200309021533-0128c0bbff6d/go.mod h1:
 github.com/Multi-Tier-Cloud/common v0.8.1/go.mod h1:Ami9dJDjyI6O6JHytzHoctObdB4s6jxbXi8yCxjmz2c=
 github.com/Multi-Tier-Cloud/common v0.9.0 h1:0iYjL4OdTy+2vD1h6feVlvwchJyBj0Zie9QwpbpYd2g=
 github.com/Multi-Tier-Cloud/common v0.9.0/go.mod h1:X4dcy0HbJNKazhNRSVGQyvZ97jetSbRweI6W9K/iTb4=
+github.com/Multi-Tier-Cloud/common v0.9.1-0.20200802182723-020620a0455b h1:ZWZwoppBwaXY0uVAltLLQxry95/2KJ0HqnGyog/VK1U=
+github.com/Multi-Tier-Cloud/common v0.9.1-0.20200802182723-020620a0455b/go.mod h1:X4dcy0HbJNKazhNRSVGQyvZ97jetSbRweI6W9K/iTb4=
 github.com/Multi-Tier-Cloud/docker-driver v0.0.0-20200323084307-72982cb10a89/go.mod h1:dwW1GHo7N7DFF4Ra6m1YH2P41LrC573oX16rnjIP2jM=
 github.com/Multi-Tier-Cloud/docker-driver v0.1.0 h1:GyeiFNWVLBKtA+Phwb5cmn7Nc3MsTlD+rthlzebwPQ8=
 github.com/Multi-Tier-Cloud/docker-driver v0.1.0/go.mod h1:HcQpH9PaHU8neSqmk5kD/oQjezwcgS7FxX/yIkPrKNY=

--- a/l4-proxy/l4-proxy.go
+++ b/l4-proxy/l4-proxy.go
@@ -126,7 +126,7 @@ func findOrAllocate(servName string, servInfo registry.ServiceInfo) (peer.ID, er
                         break
                     }
                 }
-            } else if p2putil.PerfIndCompare(servInfo.NetworkSoftReq, perf) {
+            } else if servInfo.NetworkSoftReq.LessThan(perf) {
                 log.Printf("Found service's RTT (%s) is greater than requirement (%s)\n",
                                 perf.RTT, servInfo.NetworkSoftReq.RTT)
                 log.Println("Creating new service instance")

--- a/lca/lca-manager.go
+++ b/lca/lca-manager.go
@@ -93,7 +93,7 @@ func (lca *LCAManager) AllocBetterService(
 
     // Request allocation until one succeeds then return allocated service address
     for _, p := range peers {
-        if p2putil.PerfIndCompare(perf, p.Perf) {
+        if perf.LessThan(p.Perf) {
             return peer.ID(""), "", p2putil.PerfInd{}, errors.New("Could not find better service")
         }
         log.Println("Attempting to contact peer with pid:", p.ID)

--- a/pcache/pcache.go
+++ b/pcache/pcache.go
@@ -46,8 +46,8 @@ type PeerCache struct {
     rcache  *rcache.RegistryCache
 }
 
-func RPeerInfoCompare(l, r RPeerInfo) bool {
-    return p2putil.PerfIndCompare(l.Info.Perf, r.Info.Perf)
+func (l *RPeerInfo) LessThan(r RPeerInfo) bool {
+    return l.Info.Perf.LessThan(r.Info.Perf)
 }
 
 // Constructor for PeerCache
@@ -172,12 +172,12 @@ func (cache *PeerCache) updateCache() {
 
             // If peer isn't up or doesn't meet hard requirements remove from cache
             perf := p2putil.PerfInd{RTT: result.RTT}
-            if result.RTT == 0 || p2putil.PerfIndCompare(servInfo.NetworkHardReq, perf) {
+            if result.RTT == 0 || servInfo.NetworkHardReq.LessThan(perf) {
                 cache.Levels[l] = rpfs(cache.Levels[l], uint(i))
                 // Decrement i to account for rpfs
                 i--
             // If peer is up and doesn't meet requirements decrement RCount by 10
-            } else if p2putil.PerfIndCompare(servInfo.NetworkSoftReq, perf) {
+            } else if servInfo.NetworkSoftReq.LessThan(perf) {
                 peerRlb.Info.Perf = perf
                 if peerRlb.RCount < 10 {
                     peerRlb.RCount = 0
@@ -235,7 +235,7 @@ func (cache *PeerCache) updateCache() {
     // Third pass: sort elements based on performance
     for l := uint(0); l < nLevels; l++ {
         sort.Slice(cache.Levels[l], func(i, j int) bool {
-            return RPeerInfoCompare(cache.Levels[l][i], cache.Levels[l][j])
+            return cache.Levels[l][i].LessThan(cache.Levels[l][j])
         })
     }
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -99,7 +99,7 @@ func runRequest(servName string, servInfo registry.ServiceInfo, req *http.Reques
                         break
                     }
                 }
-            } else if p2putil.PerfIndCompare(servInfo.NetworkSoftReq, perf) {
+            } else if servInfo.NetworkSoftReq.LessThan(perf) {
                 log.Printf("Found service's performance (%s) does not meet requirements (%s)\n", perf, servInfo.NetworkSoftReq)
                 id, serviceAddress, _, err = manager.AllocBetterService(dockerHash, perf)
                 if err != nil {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -49,23 +49,22 @@ var registryCache *rcache.RegistryCache
 func runRequest(servName string, servInfo registry.ServiceInfo, req *http.Request) (*http.Response, error) {
     var err error
     var id peer.ID
-    var serviceAddress string
     var perf p2putil.PerfInd
     serviceHash := servInfo.ContentHash
     dockerHash := servInfo.DockerHash
 
     // 2. Search for cached instances, allocate new instance if none found
     id, err = peerCache.GetPeer(serviceHash)
-    log.Printf("Get peer returned ID %s, serviceAddr %s, and err %v\n", id, serviceAddress, err)
-    if err != nil {
+    if err == nil {
+        log.Printf("Found cached peer with ID %s for service %s\n", id, servName)
+    } else {
         // Search for an instance in the network, allocating a new one if need be.
         // Maximum of 3 allocation attempts.
         // TODO: It's totally possible for an allocation attempt to succeed,
         // but the service takes a long time to come up, leading to subsequent
         // allocation attempts. This is a future problem to solve.
-        serviceAddress = ""
         startTime := time.Now()
-        for attempts := 0; attempts < 3 && serviceAddress == ""; attempts++ {
+        for attempts := 0; attempts < 3 && id == peer.ID(""); attempts++ {
             if attempts > 0 {
                 log.Printf("Unable to successfully find or allocate, retrying...")
             }
@@ -74,12 +73,13 @@ func runRequest(servName string, servInfo registry.ServiceInfo, req *http.Reques
             //       Need to combine AllocService and AllocBetterService
             //       Need to obtain perf req from registry-service
             log.Println("Finding best existing service instance")
-            id, serviceAddress, perf, err = manager.FindService(serviceHash)
+            id, perf, err = manager.FindService(serviceHash)
             if err != nil {
                 log.Println("Could not find, creating new service instance")
-                _, _, _, err = manager.AllocService(dockerHash)
+                _, _, err = manager.AllocService(dockerHash)
                 if err != nil {
                     log.Println("Service allocation failed\n", err)
+                    continue // Or return error right away?
                 }
 
                 // Re-do FindService() to ensure the new instance is connected
@@ -94,20 +94,20 @@ func runRequest(servName string, servInfo registry.ServiceInfo, req *http.Reques
                     log.Printf("ERROR: Unable to create ExpoBackoffAttempts\n")
                 }
                 for backoff.Attempt() {
-                    id, serviceAddress, perf, err = manager.FindService(serviceHash)
-                    if err == nil && serviceAddress != "" {
+                    id, perf, err = manager.FindService(serviceHash)
+                    if err == nil {
                         break
                     }
                 }
             } else if servInfo.NetworkSoftReq.LessThan(perf) {
                 log.Printf("Found service's performance (%s) does not meet requirements (%s)\n", perf, servInfo.NetworkSoftReq)
-                id, serviceAddress, _, err = manager.AllocBetterService(dockerHash, perf)
+                _, _, err = manager.AllocBetterService(dockerHash, perf)
                 if err != nil {
                     log.Println("No services able to be created, using previously found peer")
                 }
             }
 
-            if err == nil && serviceAddress != "" {
+            if err == nil && id != peer.ID("") {
                 // Cache peer information
                 peerCache.AddPeer(p2putil.PeerInfo{
                     ID: id,
@@ -121,11 +121,10 @@ func runRequest(servName string, servInfo registry.ServiceInfo, req *http.Reques
         log.Println("Find/alloc service took:", elapsedTime)
     }
 
-    if serviceAddress == "" || id == peer.ID("") {
+    if id == peer.ID("") {
         return nil, errors.New("Not found")
     }
-    log.Printf("Running request to peer ID %s, serviceAddr %s\n",
-               id, serviceAddress)
+    log.Printf("Running request to peer ID %s\n", id)
     resp, err := manager.Request(id, req)
     if err != nil {
         log.Printf("ERROR: HTTP request over P2P failed\n%v\n", err)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -55,7 +55,7 @@ func runRequest(servName string, servInfo registry.ServiceInfo, req *http.Reques
     dockerHash := servInfo.DockerHash
 
     // 2. Search for cached instances, allocate new instance if none found
-    id, serviceAddress, err = peerCache.GetPeer(serviceHash)
+    id, err = peerCache.GetPeer(serviceHash)
     log.Printf("Get peer returned ID %s, serviceAddr %s, and err %v\n", id, serviceAddress, err)
     if err != nil {
         // Search for an instance in the network, allocating a new one if need be.
@@ -109,7 +109,11 @@ func runRequest(servName string, servInfo registry.ServiceInfo, req *http.Reques
 
             if err == nil && serviceAddress != "" {
                 // Cache peer information
-                peerCache.AddPeer(pcache.PeerRequest{ID: id, Hash: serviceHash, Address: serviceAddress})
+                peerCache.AddPeer(p2putil.PeerInfo{
+                    ID: id,
+                    ServName: servName,
+                    ServHash: serviceHash,
+                })
             }
         }
 
@@ -125,7 +129,7 @@ func runRequest(servName string, servInfo registry.ServiceInfo, req *http.Reques
     resp, err := manager.Request(id, req)
     if err != nil {
         log.Printf("ERROR: HTTP request over P2P failed\n%v\n", err)
-        go peerCache.RemovePeer(id, serviceAddress)
+        go peerCache.RemovePeer(id)
     }
 
     return resp, err

--- a/rcache/registry-cache.go
+++ b/rcache/registry-cache.go
@@ -87,7 +87,9 @@ func (rc *RegistryCache) Delete(serviceName string) {
 // Try to get service info from cache
 // If not in cache or expired, request it from registry-service and add it to cache
 func (rc *RegistryCache) GetOrRequestService(serviceName string) (info registry.ServiceInfo, err error) {
-    log.Println("Looking for service with name", serviceName, "in registry cache")
+    // TODO: Log print below commented for now due to updateCache() loop in pcache, spams screen
+    //       Can uncomment when a proper logging library with different levels is implemented
+    //log.Println("Looking for service with name", serviceName, "in registry cache")
     info, ok := rc.Get(serviceName)
     if !ok {
         log.Println("Not cached or expired, try querying registry-service")


### PR DESCRIPTION
Previously the service requirement was set in the configuration file, meaning it treated all services to be the same.

We now store per-service service requirements in the registry, and thus can use those metrics to compare services and compute nodes.

Resolves #62 